### PR TITLE
검색페이지 Input 컴포넌트 구현

### DIFF
--- a/src/Components/Search/SearchInput.tsx
+++ b/src/Components/Search/SearchInput.tsx
@@ -1,16 +1,23 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import SearchIcon from 'Assets/search-icon.svg';
 import SearchIcon_Fill from 'Assets/search-fill-icon.svg';
 import styled from 'styled-components';
 import { useNavigate } from 'react-router-dom';
+
+// Dummy JSON data
+const dummyData: string[] = ['서울', '경기도', '강원도', '경상남도', '경상북도', '전라남도', '전라북도', '제주도'];
+
 interface SearchInputProps {
   type: string;
-  // disable된 input은 type을 button으로 처리했고 아니라면 input으로 처리했는데 헷갈릴려나요?
-  // 근데 사용되는 곳이 많이 없긴해서,,
 }
+
 const SearchInput: React.FC<SearchInputProps> = ({ type }) => {
   const [isFocused, setIsFocused] = useState(false);
+  const [searchValue, setSearchValue] = useState('');
+  const [selectedIndex, setSelectedIndex] = useState(-1);
+  const filteredData = dummyData.filter((item) => item.toLowerCase().includes(searchValue.toLowerCase()));
   const navigate = useNavigate();
+
   function handleInputFocus() {
     setIsFocused(true);
   }
@@ -18,29 +25,119 @@ const SearchInput: React.FC<SearchInputProps> = ({ type }) => {
   function handleInputBlur() {
     setIsFocused(false);
   }
+
   function handleSearchDetail() {
     navigate('/searchDetail');
   }
 
+  function handleInputChange(event: React.ChangeEvent<HTMLInputElement>) {
+    setSearchValue(event.target.value);
+    setSelectedIndex(-1);
+  }
+
+  function handleSelectOption(option: string) {
+    setSearchValue(option);
+  }
+
+  function handleSearchIconClick(event: React.MouseEvent<HTMLImageElement>) {
+    event.stopPropagation();
+    handleSearchValueCheck();
+  }
+
+  function handleKeyDown(event: React.KeyboardEvent<HTMLInputElement>) {
+    if (event.key === 'Enter') {
+      handleSearchValueCheck();
+    }
+  }
+  function handleSearchValueCheck() {
+    alert(searchValue);
+  }
+
+  function highlightMatchedText(text: string): JSX.Element {
+    const index = text.toLowerCase().indexOf(searchValue.toLowerCase());
+    if (index === -1) return <>{text}</>;
+    return (
+      <>
+        {text.slice(0, index)}
+        <SHighlight>{text.slice(index, index + searchValue.length)}</SHighlight>
+        {text.slice(index + searchValue.length)}
+      </>
+    );
+  }
+
+  useEffect(() => {
+    // 방향키랑 엔터로 드롭박스 이동가능하도록 하는 함수
+    function handleKeyDown(event: KeyboardEvent) {
+      if (isFocused && filteredData.length > 0) {
+        switch (event.key) {
+          case 'ArrowUp':
+            setSelectedIndex((prevIndex) => (prevIndex <= 0 ? filteredData.length - 1 : prevIndex - 1));
+            break;
+          case 'ArrowDown':
+            setSelectedIndex((prevIndex) => (prevIndex >= filteredData.length - 1 ? 0 : prevIndex + 1));
+            break;
+          case 'Enter':
+            if (selectedIndex !== -1) {
+              handleSelectOption(filteredData[selectedIndex]);
+            }
+            break;
+          default:
+            break;
+        }
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [isFocused, selectedIndex, filteredData]);
+
   return (
     <>
       {type === 'button' ? (
-        <SLayout isFocused={isFocused} onClick={handleSearchDetail}>
-          <SSearch type='text' placeholder='원하는 지역을 검색하세요' isFocused={isFocused} readOnly />
-          <SSearchIcon src={SearchIcon} alt='' />
-        </SLayout>
+        <>
+          <SLayout isFocused={isFocused} onClick={handleSearchDetail}>
+            <SSearch type='text' placeholder='원하는 지역을 검색하세요' isFocused={isFocused} readOnly />
+            <SSearchIcon src={SearchIcon} alt='검색아이콘' />
+          </SLayout>
+        </>
       ) : (
-        <SLayout isFocused={isFocused}>
-          <SSearch
-            type='text'
-            placeholder='원하는 지역을 검색하세요'
-            isFocused={isFocused}
-            onFocus={handleInputFocus}
-            onBlur={handleInputBlur}
-            autoFocus
-          />
-          {isFocused ? <SSearchIcon src={SearchIcon_Fill} alt='' /> : <SSearchIcon src={SearchIcon} alt='' />}
-        </SLayout>
+        <>
+          <SLayout isFocused={isFocused}>
+            <SSearch
+              type='text'
+              placeholder='원하는 지역을 검색하세요'
+              isFocused={isFocused}
+              onFocus={handleInputFocus}
+              onBlur={handleInputBlur}
+              autoFocus
+              value={searchValue}
+              onChange={handleInputChange}
+              onKeyDown={handleKeyDown}
+            />
+            {isFocused && searchValue.length > 0 && (
+              <>
+                <SDropdown>
+                  {filteredData.map((option, index) => (
+                    <SDropdownOption
+                      key={option}
+                      onClick={() => handleSelectOption(option)}
+                      isSelected={index === selectedIndex}
+                    >
+                      {highlightMatchedText(option)}
+                    </SDropdownOption>
+                  ))}
+                </SDropdown>
+              </>
+            )}
+            {isFocused ? (
+              <SSearchIcon src={SearchIcon_Fill} alt='검색아이콘' onClick={handleSearchIconClick} />
+            ) : (
+              <SSearchIcon src={SearchIcon} alt='검색아이콘' onClick={handleSearchIconClick} />
+            )}
+          </SLayout>
+        </>
       )}
     </>
   );
@@ -52,6 +149,7 @@ const SLayout = styled.div<{ isFocused: boolean }>`
   display: flex;
   width: 100%;
   height: 56px;
+  position: relative;
 `;
 
 const SSearch = styled.input<{ isFocused: boolean }>`
@@ -75,6 +173,42 @@ const SSearch = styled.input<{ isFocused: boolean }>`
 const SSearchIcon = styled.img`
   position: absolute;
   left: 86%;
-  bottom: 89%;
+  bottom: 30%;
   width: 24px;
+  cursor: pointer;
+`;
+const SDropdown = styled.div`
+  position: absolute;
+  top: 100%;
+  left: 0;
+  width: 100%;
+  max-height: 150px;
+  background-color: #fff;
+  border: 1px solid #e6e6e6;
+  border-radius: 6px;
+  overflow-y: auto;
+  z-index: 1;
+`;
+
+const SHighlight = styled.span`
+  color: #f68e1d;
+`;
+interface SDropdownOptionProps {
+  isSelected: boolean;
+}
+
+const SDropdownOption = styled.div<SDropdownOptionProps>`
+  padding: 8px 16px;
+  cursor: pointer;
+
+  &:hover {
+    background-color: #f9f9f9;
+  }
+
+  ${(props) =>
+    props.isSelected &&
+    `
+    background-color: #f9f9f9;
+    font-weight: bold;
+  `}
 `;

--- a/src/Components/Search/SearchInput.tsx
+++ b/src/Components/Search/SearchInput.tsx
@@ -1,0 +1,80 @@
+import React, { useState } from 'react';
+import SearchIcon from 'Assets/search-icon.svg';
+import SearchIcon_Fill from 'Assets/search-fill-icon.svg';
+import styled from 'styled-components';
+import { useNavigate } from 'react-router-dom';
+interface SearchInputProps {
+  type: string;
+  // disable된 input은 type을 button으로 처리했고 아니라면 input으로 처리했는데 헷갈릴려나요?
+  // 근데 사용되는 곳이 많이 없긴해서,,
+}
+const SearchInput: React.FC<SearchInputProps> = ({ type }) => {
+  const [isFocused, setIsFocused] = useState(false);
+  const navigate = useNavigate();
+  function handleInputFocus() {
+    setIsFocused(true);
+  }
+
+  function handleInputBlur() {
+    setIsFocused(false);
+  }
+  function handleSearchDetail() {
+    navigate('/searchDetail');
+  }
+
+  return (
+    <>
+      {type === 'button' ? (
+        <SLayout isFocused={isFocused} onClick={handleSearchDetail}>
+          <SSearch type='text' placeholder='원하는 지역을 검색하세요' isFocused={isFocused} readOnly />
+          <SSearchIcon src={SearchIcon} alt='' />
+        </SLayout>
+      ) : (
+        <SLayout isFocused={isFocused}>
+          <SSearch
+            type='text'
+            placeholder='원하는 지역을 검색하세요'
+            isFocused={isFocused}
+            onFocus={handleInputFocus}
+            onBlur={handleInputBlur}
+            autoFocus
+          />
+          {isFocused ? <SSearchIcon src={SearchIcon_Fill} alt='' /> : <SSearchIcon src={SearchIcon} alt='' />}
+        </SLayout>
+      )}
+    </>
+  );
+};
+
+export default SearchInput;
+
+const SLayout = styled.div<{ isFocused: boolean }>`
+  display: flex;
+  width: 100%;
+  height: 56px;
+`;
+
+const SSearch = styled.input<{ isFocused: boolean }>`
+  display: flex;
+  flex: 1;
+  width: 100%;
+  height: 100%;
+  margin: 0 auto;
+  font-size: 14px;
+  padding: 6px 20px;
+  padding-right: 35px;
+  box-sizing: border-box;
+  border: 1px solid ${(props) => (props.isFocused ? '#F68E1D' : '#e6e6e6')};
+  border-radius: 6px;
+  outline: none;
+  transition: border-color 0.3s ease-in-out;
+  box-shadow: ${(props) => (props.isFocused ? '0px 0px 0px 0px' : '0px 4px 4px 0px rgba(0, 0, 0, 0.25)')};
+  color: #000;
+  position: relative;
+`;
+const SSearchIcon = styled.img`
+  position: absolute;
+  left: 86%;
+  bottom: 89%;
+  width: 24px;
+`;

--- a/src/Components/common/BottomNav.tsx
+++ b/src/Components/common/BottomNav.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import styled from 'styled-components';
 import { useRecoilState } from 'recoil';
 import { bottomNavAtom } from 'Atom/BottomNavStore';
@@ -14,7 +14,6 @@ import SettingIcon_Fill from 'Assets/setting-fill-icon.svg';
 
 const BottomNav: React.FC = () => {
   const [bottomNavIndexState, setBottomNavIndexState] = useRecoilState<number>(bottomNavAtom);
-
   const navItems: string[] = ['home', 'search', 'weekly', 'setting'];
   const iconArr: { active: string; inactive: string }[] = [
     { active: HomeIcon_Fill, inactive: HomeIcon },
@@ -23,9 +22,36 @@ const BottomNav: React.FC = () => {
     { active: SettingIcon_Fill, inactive: SettingIcon },
   ];
 
+  const location = useLocation(); // 현재 경로 정보 가져오기
+
+  // 현재 경로에 따라서 bottomNavIndexState를 업데이트하는 함수
+  const updateBottomNavIndexState = () => {
+    const path = location.pathname; // 현재 경로
+    switch (path) {
+      case '/':
+        setBottomNavIndexState(0);
+        break;
+      case '/search':
+        setBottomNavIndexState(1);
+        break;
+      case '/weekly':
+        setBottomNavIndexState(2);
+        break;
+      case '/setting':
+        setBottomNavIndexState(3);
+        break;
+      default:
+        break;
+    }
+  };
+
+  // 첫 렌더링 시 현재 경로에 따라 bottomNavIndexState 초기화
+  useEffect(() => {
+    updateBottomNavIndexState();
+  }, []);
+
   const handleClick = (index: number): void => {
     setBottomNavIndexState(index);
-    console.log(bottomNavIndexState);
   };
   return (
     <SNavLayout>

--- a/src/Components/common/BottomNav.tsx
+++ b/src/Components/common/BottomNav.tsx
@@ -25,7 +25,7 @@ const BottomNav: React.FC = () => {
   const location = useLocation(); // 현재 경로 정보 가져오기
 
   // 현재 경로에 따라서 bottomNavIndexState를 업데이트하는 함수
-  const updateBottomNavIndexState = () => {
+  function updateBottomNavIndexState() {
     const path = location.pathname; // 현재 경로
     switch (path) {
       case '/':
@@ -43,16 +43,16 @@ const BottomNav: React.FC = () => {
       default:
         break;
     }
-  };
+  }
 
   // 첫 렌더링 시 현재 경로에 따라 bottomNavIndexState 초기화
   useEffect(() => {
     updateBottomNavIndexState();
   }, []);
 
-  const handleClick = (index: number): void => {
+  function handleClick(index: number): void {
     setBottomNavIndexState(index);
-  };
+  }
   return (
     <SNavLayout>
       <SListStyle>

--- a/src/Components/common/Header.tsx
+++ b/src/Components/common/Header.tsx
@@ -1,21 +1,25 @@
 import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
 import backBtn from 'Assets/backBtn-icon.svg';
-import { useParams, useLocation } from 'react-router-dom';
+import { useParams, useLocation, useNavigate } from 'react-router-dom';
 
 const Header: React.FC = () => {
   const [headerBtn, setHeaderBtn] = useState<string | undefined>(undefined);
   const location = useLocation();
+  const navigate = useNavigate();
+  function handleBack() {
+    navigate(-1);
+  }
 
   useEffect(() => {
     const path = location.pathname.replace('/', '');
-    if (path === 'weekly' || path === 'setting') {
+    if (path === 'setting' || path === 'searchDetail') {
       setHeaderBtn(backBtn);
     }
   }, [location.pathname]);
 
   return (
-    <SLayout>
+    <SLayout onClick={handleBack}>
       <button>{headerBtn && <img src={headerBtn} alt='' />}</button>
     </SLayout>
   );
@@ -33,4 +37,5 @@ const SLayout = styled.div`
   box-sizing: border-box;
   align-items: center;
   margin-bottom: 15px;
+  cursor: pointer;
 `;

--- a/src/Pages/Search.tsx
+++ b/src/Pages/Search.tsx
@@ -1,10 +1,12 @@
+import React from 'react';
 import BottomNav from 'Components/common/BottomNav';
 import Header from 'Components/common/Header';
-import React from 'react';
+import SearchInput from 'Components/Search/SearchInput';
 const Search = () => {
   return (
     <>
       <Header />
+      <SearchInput type='button' />
       <BottomNav />
     </>
   );

--- a/src/Pages/SearchDetail.tsx
+++ b/src/Pages/SearchDetail.tsx
@@ -1,0 +1,14 @@
+import SearchInput from 'Components/Search/SearchInput';
+import Header from 'Components/common/Header';
+import React from 'react';
+
+const SearchDetail = () => {
+  return (
+    <div>
+      <Header />
+      <SearchInput type='input' />
+    </div>
+  );
+};
+
+export default SearchDetail;

--- a/src/Router/Router.tsx
+++ b/src/Router/Router.tsx
@@ -5,6 +5,7 @@ import Login from 'Pages/Login';
 import Search from 'Pages/Search';
 import Weekly from 'Pages/Weekly';
 import Setting from 'Pages/Setting';
+import SearchDetail from 'Pages/SearchDetail';
 
 const router = createBrowserRouter([
   {
@@ -30,6 +31,10 @@ const router = createBrowserRouter([
       {
         path: 'setting',
         element: <Setting />,
+      },
+      {
+        path: 'searchDetail',
+        element: <SearchDetail />,
       },
     ],
   },


### PR DESCRIPTION
### 이슈번호: #3 #10 

## 전달 사항
#10
- Search 페이지와 Search Detail에서 사용되는 input 컴포넌트 구현.
- Search 페이지에선 readOnly로 설정, 클릭 시 SearchDetail로 넘어가고 autoFocus되도록 구현.
- Input 컴포넌트 사용 시 string으로 type을 받는데 disable된 상태는 button으로, 아니면 input으로 설정해놓음.
  - 헷갈린다면 수정하면되는데 사용되는 곳이 적어서 상관없을지도.
  
#3 
- 바텀네비게이션 뒤로가기로 이동 시 제대로 active되지않는 버그 있어서 location으로 현재경로에 맞게 useEffect로 확인하도록 수정.

## 추후 작업
- 검색목록 JSON이나 따로 API 알아보고 검색기능 구현.
