### PR TITLE
주간예보 UI 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+.env

--- a/src/Components/Weekly/WeeklyForecast.tsx
+++ b/src/Components/Weekly/WeeklyForecast.tsx
@@ -1,0 +1,96 @@
+import React, { FC } from 'react';
+import WeeklyItem from 'Components/Weekly/WeeklyItem';
+import smallWeatherIcons from 'Components/common/smallWeatherIcons';
+import { styled } from 'styled-components';
+
+const WeeklyForecast: FC = () => {
+  // mock data
+  const week = [
+    {
+      dt: '오늘',
+      main: {
+        temp: '28°',
+        min: '21°',
+        max: '32°',
+        icon: smallWeatherIcons.clearSky,
+      },
+    },
+    {
+      dt: '수',
+      main: {
+        temp: '29°',
+        min: '22°',
+        max: '33°',
+        icon: smallWeatherIcons.brokenClouds,
+      },
+    },
+    {
+      dt: '목',
+      main: {
+        temp: '32°',
+        min: '24°',
+        max: '32°',
+        icon: smallWeatherIcons.fewClouds,
+      },
+    },
+    {
+      dt: '금',
+      main: {
+        temp: '27°',
+        min: '22°',
+        max: '30°',
+        icon: smallWeatherIcons.rainy,
+      },
+    },
+    {
+      dt: '토',
+      main: {
+        temp: '28°',
+        min: '25°',
+        max: '31°',
+        icon: smallWeatherIcons.showerRainy,
+      },
+    },
+    {
+      dt: '일',
+      main: {
+        temp: '28°',
+        min: '21°',
+        max: '32°',
+        icon: smallWeatherIcons.rainyThunder,
+      },
+    },
+  ];
+
+  return (
+    <>
+      <STitle>주간 일기예보</STitle>
+      <SLayout>
+        {week.map((day, idx) => (
+          <WeeklyItem
+            key={idx}
+            day={day.dt}
+            min={day.main.min}
+            max={day.main.max}
+            temp={day.main.temp}
+            icon={day.main.icon}
+          />
+        ))}
+      </SLayout>
+    </>
+  );
+};
+
+export default WeeklyForecast;
+
+const STitle = styled.h1`
+  margin-bottom: 40px;
+  font-size: 24px;
+  font-weight: 600;
+`;
+
+const SLayout = styled.main`
+  display: flex;
+  flex-direction: column;
+  gap: 25px;
+`;

--- a/src/Components/Weekly/WeeklyItem.tsx
+++ b/src/Components/Weekly/WeeklyItem.tsx
@@ -1,0 +1,73 @@
+import React, { FC } from 'react';
+import styled from 'styled-components';
+
+interface WeeklyItemProps {
+  day: string | number | undefined;
+  min: string | number | undefined;
+  max: string | number | undefined;
+  temp: string | number | undefined;
+  icon?: string | undefined;
+}
+
+const WeeklyItem: FC<WeeklyItemProps> = ({ day, min, max, temp, icon }) => {
+  return (
+    <SLayout>
+      <h2>{day}</h2>
+      <SMinMaxWrap>
+        <span>최저: {min}</span>
+        <span>최고: {max}</span>
+      </SMinMaxWrap>
+      <STempWrap>
+        <img src={icon} alt='이날의 날씨 아이콘' />
+        <span>{temp}</span>
+      </STempWrap>
+    </SLayout>
+  );
+};
+
+export default WeeklyItem;
+
+const SLayout = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 20px 21px;
+  background-color: #fff;
+  border: 1px solid var(--gray-400);
+  border-radius: 10px;
+
+  h2 {
+    font-size: 20px;
+    font-weight: 500;
+  }
+`;
+
+const SMinMaxWrap = styled.div`
+  font-size: 12px;
+  color: var(--gray-800);
+
+  span:nth-of-type(1)::after {
+    content: '';
+    display: inline-block;
+    width: 0.5px;
+    height: 12px;
+    margin: 0 7px;
+    vertical-align: top;
+    background-color: var(--gray-400);
+  }
+`;
+
+const STempWrap = styled.div`
+  display: flex;
+  align-items: center;
+
+  img {
+    margin-right: 3px;
+  }
+
+  span {
+    font-size: 24px;
+    font-weight: bold;
+    color: var(--orange);
+  }
+`;

--- a/src/Components/Weekly/WeeklyTest.tsx
+++ b/src/Components/Weekly/WeeklyTest.tsx
@@ -1,5 +1,0 @@
-const WeeklyTest = () => {
-  return <div>WeeklyTest</div>;
-};
-
-export default WeeklyTest;

--- a/src/Components/common/smallWeatherIcons.ts
+++ b/src/Components/common/smallWeatherIcons.ts
@@ -1,0 +1,23 @@
+import brokenClouds from 'Assets/icons-sm-weather/icon-broken-clouds.svg';
+import clearSky from 'Assets/icons-sm-weather/icon-clear-sky.svg';
+import fewClouds from 'Assets/icons-sm-weather/icon-few-clouds.svg';
+import mist from 'Assets/icons-sm-weather/icon-mist.svg';
+import rainyThunder from 'Assets/icons-sm-weather/icon-rainy-thunder.svg';
+import rainy from 'Assets/icons-sm-weather/icon-rainy.svg';
+import scatteredClouds from 'Assets/icons-sm-weather/icon-scattered-clouds.svg';
+import showerRainy from 'Assets/icons-sm-weather/icon-shower-rainy.svg';
+import snow from 'Assets/icons-sm-weather/icon-snow.svg';
+
+const smallWeatherIcons = {
+  brokenClouds: brokenClouds,
+  clearSky: clearSky,
+  fewClouds: fewClouds,
+  mist: mist,
+  rainyThunder: rainyThunder,
+  rainy: rainy,
+  scatteredClouds: scatteredClouds,
+  showerRainy: showerRainy,
+  snow: snow,
+};
+
+export default smallWeatherIcons;

--- a/src/Pages/Weekly.tsx
+++ b/src/Pages/Weekly.tsx
@@ -1,11 +1,13 @@
-import BottomNav from 'Components/common/BottomNav';
-import Header from 'Components/common/Header';
 import React from 'react';
+import Header from 'Components/common/Header';
+import BottomNav from 'Components/common/BottomNav';
+import WeeklyForecast from 'Components/Weekly/WeeklyForecast';
 
 const Weekly = () => {
   return (
     <>
       <Header />
+      <WeeklyForecast />
       <BottomNav />
     </>
   );


### PR DESCRIPTION
## 전달사항
- 주간예보 UI 마크업 
  - 주간 일기예보의 각 item을 재사용 컴포넌트로 분리
  - item을 목업 데이터로 map으로 데이터 길이만큼 렌더링
  - 임의 smallWeatherIcons 파일 생성 

## 진행예정
- 5day API 파일 연결 및 함수 생성 예정
- 임의 smallWeatherIcons를 API의 weather.main에 연결 하여 조건부로 props 전달

## 기타사항
- API 사용을 위한 .gitignore .env 추가