### PR TITLE
주간예보 기능

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6,22 +6,7 @@
   <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="theme-color" content="#000000" />
-  <meta name="description" content="Web site created using create-react-app" />
-  <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
-  <!--
-      manifest.json provides metadata used when your web app is installed on a
-      user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
-    -->
-  <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-  <!--
-      Notice the use of %PUBLIC_URL% in the tags above.
-      It will be replaced with the URL of the `public` folder during the build.
-      Only files inside the `public` folder can be referenced from the HTML.
-
-      Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
-      work correctly both with client-side routing and a non-root public URL.
-      Learn how to configure a non-root public URL by running `npm run build`.
-    -->
+  <meta name="description" content="날씨 제공 어플리케이션" />
   <title>WWW</title>
 </head>
 

--- a/src/API/openWeatherAPI_Config.ts
+++ b/src/API/openWeatherAPI_Config.ts
@@ -1,4 +1,5 @@
 export const config = {
-  API_ID: 'c7f82955ebcd743198b54b7aa82fbdf4',
+  API_ID: process.env.REACT_APP_WEATHER_API_KEY,
   BaseURL: 'http://api.openweathermap.org/data/2.5/weather',
+  ForeCastURL: 'http://api.openweathermap.org/data/2.5/forecast',
 };

--- a/src/API/useOpenWeatherAPI.tsx
+++ b/src/API/useOpenWeatherAPI.tsx
@@ -6,10 +6,13 @@ const useOpenWeatherAPI = () => {
   const openWeatherAxios = axios.create({
     baseURL: config.BaseURL,
   });
+  const forecastAxios = axios.create({
+    baseURL: config.ForeCastURL,
+  });
 
-  async function getCityWeather(latLonData: { longitude: number; latitude: number }) {
-    const lat = latLonData.latitude;
-    const lon = latLonData.longitude;
+  async function getCityWeather(latLonData: { longitude: number; latitude: number; lat?: number; lon?: number }) {
+    const lat = latLonData.latitude || latLonData.lat;
+    const lon = latLonData.longitude || latLonData.lon;
     const requestURL = `?lat=${lat}&lon=${lon}&appid=${API_ID}&units=metric`;
     try {
       const response = await openWeatherAxios.get(requestURL).then((response) => response.data);
@@ -19,7 +22,20 @@ const useOpenWeatherAPI = () => {
     }
   }
 
-  return { getCityWeather };
+  async function getForecast(latLonData: { lat: number; lon: number }) {
+    const lat = latLonData.lat;
+    const lon = latLonData.lon;
+    const reqURL = `?lat=${lat}&lon=${lon}&appid=${API_ID}&units=metric`;
+
+    try {
+      const response = await forecastAxios.get(reqURL).then((res) => res.data);
+      return response;
+    } catch (error) {
+      console.error('Forecast API 문제가 있습니다.', error);
+    }
+  }
+
+  return { getCityWeather, getForecast };
 };
 
 export default useOpenWeatherAPI;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import GlobalStyle from 'GlobalStyle';
 import SLayout from 'Components/style/SLayout';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { ReactQueryDevtools } from 'react-query/devtools';
+import { StyleSheetManager } from 'styled-components';
 
 const queryClient = new QueryClient();
 
@@ -21,10 +22,12 @@ function App() {
     <QueryClientProvider client={queryClient}>
       <ReactQueryDevtools initialIsOpen={true} />
       <RecoilRoot>
-        <SLayout>
-          <GlobalStyle />
-          <Outlet />
-        </SLayout>
+        <StyleSheetManager shouldForwardProp={(prop) => prop !== 'active'}>
+          <SLayout>
+            <GlobalStyle />
+            <Outlet />
+          </SLayout>
+        </StyleSheetManager>
       </RecoilRoot>
     </QueryClientProvider>
   );

--- a/src/Components/Weekly/WeeklyForecast.tsx
+++ b/src/Components/Weekly/WeeklyForecast.tsx
@@ -7,6 +7,7 @@ import useOpenWeatherAPI from 'API/useOpenWeatherAPI';
 import { userLocationAtom } from 'Atom/userLocationAtom';
 import formatDateTime from 'Utils/formatDateTime';
 import filterMinMax from 'Utils/filterMinMax';
+import { useWeatherIcon } from 'Components/common/useWeatherIcon';
 
 import { ItemType } from 'types/weeklyType';
 
@@ -19,6 +20,7 @@ const WeeklyForecast: FC = () => {
   const weeklyRes = useQuery('weeklyForecast', () => getForecast(latLonData));
 
   const today = cityRes?.data;
+  const todayIcon = useWeatherIcon(today?.weather.main);
 
   // 주간예보 필터링 effect
   useEffect(() => {
@@ -40,8 +42,6 @@ const WeeklyForecast: FC = () => {
     }
   }, [weeklyRes.data]);
 
-  console.log(days);
-
   if (weeklyRes.isLoading) {
     return <p>로딩중...</p>;
   }
@@ -59,6 +59,7 @@ const WeeklyForecast: FC = () => {
           min={Math.ceil(today?.main.temp_min) + '°'}
           max={Math.ceil(today?.main.temp_max) + '°'}
           temp={Math.ceil(today?.main.temp) + '°'}
+          icon={todayIcon}
         />
         {days.map((day, idx) => (
           <WeeklyItem
@@ -67,7 +68,8 @@ const WeeklyForecast: FC = () => {
             min={Math.ceil(day.main.temp_min) + '°'}
             max={Math.ceil(day.main.temp_max) + '°'}
             temp={Math.ceil(day.main.temp) + '°'}
-            // icon={day.main.icon}
+            // eslint-disable-next-line
+            icon={useWeatherIcon(day.weather[0].main)}
           />
         ))}
       </SLayout>

--- a/src/Components/Weekly/WeeklyForecast.tsx
+++ b/src/Components/Weekly/WeeklyForecast.tsx
@@ -1,21 +1,73 @@
-import React, { FC } from 'react';
-import WeeklyItem from 'Components/Weekly/WeeklyItem';
-import week from 'Mock/weather';
+import React, { FC, useEffect, useState } from 'react';
 import { styled } from 'styled-components';
+import { useQuery } from 'react-query';
+import { useRecoilValue } from 'recoil';
+import WeeklyItem from 'Components/Weekly/WeeklyItem';
+import useOpenWeatherAPI from 'API/useOpenWeatherAPI';
+import { userLocationAtom } from 'Atom/userLocationAtom';
+import formatDateTime from 'Utils/formatDateTime';
+import filterMinMax from 'Utils/filterMinMax';
+
+import { ItemType } from 'types/weeklyType';
 
 const WeeklyForecast: FC = () => {
+  const latLonData = useRecoilValue(userLocationAtom);
+  const { getCityWeather, getForecast } = useOpenWeatherAPI();
+  const [days, setDays] = useState<ItemType[]>([]);
+
+  const cityRes = useQuery('cityWeather', () => getCityWeather(latLonData));
+  const weeklyRes = useQuery('weeklyForecast', () => getForecast(latLonData));
+
+  const today = cityRes?.data;
+
+  // 주간예보 필터링 effect
+  useEffect(() => {
+    if (weeklyRes.data) {
+      const objectData = weeklyRes.data?.list;
+      const dataArray: ItemType[] = Object.values(objectData);
+      const changedDtArr = dataArray.map((item) => {
+        const formattedDate = formatDateTime(item.dt_txt); // 새로운 날짜 포맷
+
+        return {
+          ...item,
+          dt: formattedDate,
+        };
+      });
+
+      const filteredData = filterMinMax(changedDtArr);
+
+      setDays(filteredData);
+    }
+  }, [weeklyRes.data]);
+
+  console.log(days);
+
+  if (weeklyRes.isLoading) {
+    return <p>로딩중...</p>;
+  }
+
+  if (weeklyRes.isError) {
+    return <p>주간예보 날씨가 존재하지 않습니다.</p>;
+  }
+
   return (
     <>
-      <STitle>주간 일기예보</STitle>
+      <STitle>{weeklyRes.data?.city.name} 주간 일기예보</STitle>
       <SLayout>
-        {week.map((day, idx) => (
+        <WeeklyItem
+          day='오늘'
+          min={Math.ceil(today?.main.temp_min) + '°'}
+          max={Math.ceil(today?.main.temp_max) + '°'}
+          temp={Math.ceil(today?.main.temp) + '°'}
+        />
+        {days.map((day, idx) => (
           <WeeklyItem
             key={idx}
             day={day.dt}
-            min={day.main.min}
-            max={day.main.max}
-            temp={day.main.temp}
-            icon={day.main.icon}
+            min={Math.ceil(day.main.temp_min) + '°'}
+            max={Math.ceil(day.main.temp_max) + '°'}
+            temp={Math.ceil(day.main.temp) + '°'}
+            // icon={day.main.icon}
           />
         ))}
       </SLayout>

--- a/src/Pages/Home.tsx
+++ b/src/Pages/Home.tsx
@@ -4,7 +4,7 @@ import BottomNav from 'Components/common/BottomNav';
 import Character from 'Components/Home/Character';
 import ParticulateMatter from 'Components/Home/ParticulateMatter';
 
-import HourlyForcast from 'Components/Home/HourlyForecast';
+import HourlyForecast from 'Components/Home/HourlyForecast';
 import SpeechBubble from 'Components/Home/SpeechBubble';
 import { useNavigate, useLocation } from 'react-router';
 
@@ -20,7 +20,7 @@ const Home = () => {
         <Character />
         <SPMHourlySection>
           <ParticulateMatter />
-          <HourlyForcast />
+          <HourlyForecast />
         </SPMHourlySection>
       </main>
       <BottomNav />

--- a/src/Utils/filterMinMax.ts
+++ b/src/Utils/filterMinMax.ts
@@ -1,0 +1,50 @@
+import { ItemType } from 'types/weeklyType';
+
+function filterMinMax(changedDtArr: ItemType[]): ItemType[] {
+  const selectedDataArray = changedDtArr.filter((item) => item.dt !== '오늘');
+
+  // dt 값별로 객체들을 그룹화, groupedData에 저장
+  const groupedData: { [key: string]: ItemType[] } = {};
+  selectedDataArray.forEach((item) => {
+    if (!groupedData[item.dt]) {
+      groupedData[item.dt] = [];
+    }
+    groupedData[item.dt].push(item);
+  });
+
+  // 필터링 값
+  const filteredData: ItemType[] = [];
+
+  // 최저 중 가장 작은 값, 최고 중 가장 큰 값인 객체 필터링
+  for (const dt in groupedData) {
+    const items = groupedData[dt];
+
+    // 최저가 가장 작은 객체의 인덱스 찾기
+    let minTempIndex = 0;
+    for (let i = 1; i < items.length; i++) {
+      if (items[i].main.temp_min < items[minTempIndex].main.temp_min) {
+        minTempIndex = i;
+      }
+    }
+
+    // 최고가 가장 큰 객체의 인덱스 찾기
+    let maxTempIndex = 0;
+    for (let i = 1; i < items.length; i++) {
+      if (items[i].main.temp_max > items[maxTempIndex].main.temp_max) {
+        maxTempIndex = i;
+      }
+    }
+
+    filteredData.push({
+      ...items[minTempIndex], // temp_min이 가장 작은 값을 가진 객체
+      main: {
+        ...items[minTempIndex].main, // main 타입도 복사하여 변경
+        temp_max: items[maxTempIndex].main.temp_max, // temp_max만 변경
+      },
+    });
+  }
+
+  return filteredData;
+}
+
+export default filterMinMax;

--- a/src/Utils/formatDateTime.ts
+++ b/src/Utils/formatDateTime.ts
@@ -1,0 +1,23 @@
+function formatDateTime(dt_txt: string) {
+  const daysOfWeek = ['일', '월', '화', '수', '목', '금', '토'];
+
+  const dateParts = dt_txt.split(' ')[0].split('-'); // "2023-08-09"를 '-'로 분할
+  const year = parseInt(dateParts[0]);
+  const month = parseInt(dateParts[1]) - 1; // JavaScript의 월은 0부터 시작
+  const day = parseInt(dateParts[2]);
+
+  const date = new Date(year, month, day);
+  const today = new Date();
+
+  const isToday = date.toDateString() === today.toDateString();
+
+  let formattedDay = daysOfWeek[date.getDay()];
+
+  if (isToday) {
+    formattedDay = '오늘';
+  }
+
+  return formattedDay;
+}
+
+export default formatDateTime;

--- a/src/types/weeklyType.ts
+++ b/src/types/weeklyType.ts
@@ -1,0 +1,44 @@
+export type CloudsType = {
+  all: number;
+};
+
+export type WeatherType = {
+  id: number;
+  main: string;
+  description: string;
+  icon: string;
+};
+
+export type MainType = {
+  temp: number;
+  feels_like: number;
+  temp_min: number;
+  temp_max: number;
+  pressure: number;
+  sea_level: number;
+  grnd_level: number;
+  humidity: number;
+  temp_kf: number;
+};
+
+export type WindType = {
+  speed: number;
+  deg: number;
+  gust: number;
+};
+
+export type SysType = {
+  pod: string;
+};
+
+export type ItemType = {
+  dt: string;
+  dt_txt: string;
+  clouds: CloudsType;
+  main: MainType;
+  pop: number;
+  sys: SysType;
+  visibility: number;
+  weather: WeatherType[];
+  wind: WindType;
+};


### PR DESCRIPTION
## 전달사항 
- 주간예보 API 데이터의 타입 생성 및 파일 분리
- 새로운 날짜 포맷 생성해주는 함수 생성, 파일 분리
  - dt 기준으로 하려고하니 현재 시간 이후의 오늘은 내일로 출력이 되더라구요. 그래서 
- 최저 및 최고 필터링 함수 생성, 파일 분리
- 주간예보 API 추가 
  - useOpenWeatherAPI에 getForecast 함수로 생성했습니다.
  - getCityWeather도 오늘꺼 보여주기위해 사용해야해서 인자 타입 추가했습니다. 문제되면 얘기해주세요
- 주간예보 API 데이터 컴포넌트로 뿌려주는 기능 추가
- 주간예보 날씨 icon useWeatherIcon 사용하여 추가 

## 기타전달사항
- index.html logo 상시 에러 수정 및 주석 제거
- API config 파일의 API ID를 환경변수 API KEY로 변경
- 홈페이지에서 Forecast 오타 수정
- DOM에서 읽지 못하는 active prop 상시 에러 StyleSheetManager로 처리 