### PR TITLE
♻️Refactor: 검색기록 현재 위치 데이터 cityAtom 0번째 인덱스로 변경

### DIFF
--- a/src/API/LoatLonAPI.tsx
+++ b/src/API/LoatLonAPI.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { useQuery } from 'react-query';
+import axios from 'axios';
+
+export const LatLonAPI = () => {
+  const { isLoading, error, data } = useQuery({
+    queryKey: ['weather'],
+    queryFn: () => {
+      const response = axios.get(
+        'https://api.openweathermap.org/data/2.5/weather?lat=10.99&lon=44.34&appid=c7f82955ebcd743198b54b7aa82fbdf4',
+      );
+      return response;
+    },
+  });
+};

--- a/src/API/cityNameAPI.tsx
+++ b/src/API/cityNameAPI.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import axios from 'axios';
+import { cityNameConfig } from './openWeatherAPI_Config';
+
+const cityNameAPI = async (latlon: { latitude: number; longitude: number }) => {
+  const API_KEY = cityNameConfig.API_ID;
+  const requestURL = `https://dapi.kakao.com/v2/local/geo/coord2regioncode.json?x=${latlon.longitude}&y=${latlon.latitude}`;
+
+  const response = await axios
+    .get(requestURL, {
+      headers: { Authorization: `KakaoAK ${API_KEY}` },
+    })
+    .then((res) => res.data.documents[0])
+    .catch((error) => console.log(error));
+  return response;
+};
+
+export default cityNameAPI;

--- a/src/API/openWeatherAPI_Config.ts
+++ b/src/API/openWeatherAPI_Config.ts
@@ -3,3 +3,8 @@ export const config = {
   BaseURL: 'http://api.openweathermap.org/data/2.5/weather',
   ForeCastURL: 'http://api.openweathermap.org/data/2.5/forecast',
 };
+
+export const cityNameConfig = {
+  API_ID: process.env.REACT_APP_CITYNAME_API_KEY,
+  BaseURL: 'https://dapi.kakao.com/v2/local/geo/coord2regioncode.json?',
+};

--- a/src/API/weatherLatLonAPI.ts
+++ b/src/API/weatherLatLonAPI.ts
@@ -5,6 +5,7 @@ export const getLatLonData = async (lat: number, lon: number) => {
     .get(
       `https://api.openweathermap.org/data/2.5/weather?lat=${lat}&lon=${lon}&appid=c7f82955ebcd743198b54b7aa82fbdf4&units=metric`,
     )
-    .then((response) => response.data);
+    .then((response) => response.data)
+    .catch((error) => console.log(error));
   return response;
 };

--- a/src/Atom/userLocationAtom.ts
+++ b/src/Atom/userLocationAtom.ts
@@ -9,6 +9,6 @@ export const userLocationAtom = atom({
 });
 export const userCityAtom = atom({
   key: 'userCityAtom',
-  default: '',
+  default: [],
   effects_UNSTABLE: [persistAtom],
 });

--- a/src/Components/Permission/RejectionModal.tsx
+++ b/src/Components/Permission/RejectionModal.tsx
@@ -6,9 +6,10 @@ import Button from 'Components/common/Button';
 interface RejectionModalProps {
   handleGeo?: (() => void) | undefined;
   setShowModal?: Dispatch<SetStateAction<boolean>> | undefined;
+  showModal?: boolean;
 }
 
-const RejectionModal: FC<RejectionModalProps> = ({ handleGeo, setShowModal }) => {
+const RejectionModal: FC<RejectionModalProps> = ({ handleGeo, setShowModal, showModal }) => {
   // NOTE: 권한 재요청
   // 모바일이 아닌 브라우저에서 권한 재요청 방법을 찾아봐야함. 현재 재요청을 해도 브라우저에서 요청권한 창이 나오지 않음. 현재로서는 권한을 허용하는 방법을 안내하는 쪽으로 먼저 해보기.
   function handleRetryPermission() {

--- a/src/Components/Search/CardWaveList.tsx
+++ b/src/Components/Search/CardWaveList.tsx
@@ -1,52 +1,21 @@
 import React, { FC } from 'react';
 import { styled } from 'styled-components';
 import { Link } from 'react-router-dom';
-import CardWeather from './CardWeather';
-import { useQuery } from 'react-query';
-import { getLatLonData } from 'API/weatherLatLonAPI';
 import { useRecoilValue } from 'recoil';
-import { userLocationAtom } from 'Atom/userLocationAtom';
-import useOpenWeatherAPI from 'API/useOpenWeatherAPI';
-import useSearchedCities from 'Hooks/useSearchedCites';
 import CityWeatherCard from './CityWeatherCard';
+import { userCityAtom } from 'Atom/userLocationAtom';
+import { CityWeatherType } from 'types/cityWeatherType';
 
 const CardWaveList: FC = () => {
-  const latLon = useRecoilValue(userLocationAtom);
-  const { searchedCities } = useSearchedCities();
-
-  const { data, isLoading, isError } = useQuery('weatherLatLon', () => getLatLonData(latLon.lat, latLon.lon));
+  const searchData = useRecoilValue(userCityAtom);
 
   return (
     <CardWaveLayout to=''>
-      {isLoading ? (
-        <div>로딩중입니다</div>
-      ) : (
-        <>
-          <CardWeather
-            key={data.coord.id}
-            temp={data.main.temp}
-            max={data.main.temp_max}
-            min={data.main.temp_min}
-            weather={data.weather[0].main}
-            name='현재 나의 위치'
-          />
-          {searchedCities.map((cityInfo, index) => (
-            <CityWeatherCard key={index} cityName={cityInfo.cityName} latLonData={cityInfo.latLonData} />
-          ))}
-        </>
-      )}
-      {/* {week?.map((el, index) => {
+      {searchData.map((el: CityWeatherType, index: number) => {
         return (
-          <CardWeather
-            key={index}
-            temp={el.main.temp}
-            max={el.main.max}
-            min={el.main.min}
-            icon={el.main.icon}
-            name={el.main.name}
-          />
+          <CityWeatherCard key={index} cityName={index === 0 ? '현재 위치' : el.cityName} latLonData={el.latLonData} />
         );
-      })} */}
+      })}
     </CardWaveLayout>
   );
 };

--- a/src/Components/Search/CityWeatherCard.tsx
+++ b/src/Components/Search/CityWeatherCard.tsx
@@ -2,17 +2,10 @@ import React, { FC } from 'react';
 import CardWeather from './CardWeather';
 import { useQuery } from 'react-query';
 import useOpenWeatherAPI from 'API/useOpenWeatherAPI';
+import { CityWeatherType } from 'types/cityWeatherType';
 import useSearchedCities from 'Hooks/useSearchedCites';
 
-interface CityWeatherCardProps {
-  cityName: string;
-  latLonData: {
-    longitude: number;
-    latitude: number;
-  };
-}
-
-const CityWeatherCard: FC<CityWeatherCardProps> = ({ cityName, latLonData }) => {
+const CityWeatherCard: FC<CityWeatherType> = ({ cityName, latLonData }) => {
   const { getCityWeather } = useOpenWeatherAPI();
   const { data, isLoading, isError } = useQuery(
     ['weatherCity', latLonData], // Query key

--- a/src/Components/common/Button.tsx
+++ b/src/Components/common/Button.tsx
@@ -6,18 +6,32 @@ interface OwnProps {
   type?: 'button' | 'submit' | undefined;
   $fontSize?: string;
   onClick?: () => void;
+  showLoading?: boolean;
 }
 
-const Button: React.FC<OwnProps> = ({ type, children, ...rest }) => {
+const Button: React.FC<OwnProps> = ({ type, children, showLoading, ...rest }) => {
   return (
-    <SButtonLayout type={type ? type : 'button'} {...rest}>
-      {children}
+    <SButtonLayout
+      className={showLoading ? 'loading' : ''}
+      type={type ? type : 'button'}
+      {...rest}
+      disabled={showLoading ? true : false}
+    >
+      {showLoading ? '' : children}
+      {showLoading && (
+        <LoadingDot>
+          <div></div>
+          <div></div>
+          <div></div>
+        </LoadingDot>
+      )}
     </SButtonLayout>
   );
 };
 
 const SButtonLayout = styled.button<{ $fontSize?: string }>`
   width: 100%;
+  min-height: 60px;
   background-color: var(--orange);
   padding: 20px 0;
   border-radius: 10px;
@@ -35,6 +49,45 @@ const SButtonLayout = styled.button<{ $fontSize?: string }>`
   &:active {
     background-color: #de7e18;
     transform: scale(0.98);
+  }
+
+  &:disabled {
+    background-color: #ffbf7b;
+  }
+
+  .loading {
+  }
+`;
+
+const LoadingDot = styled.div`
+  display: flex;
+  justify-content: center;
+  gap: 20px;
+  & div {
+    width: 16px;
+    height: 16px;
+    background-color: white;
+    border-radius: 50px;
+    animation: dot 1s linear infinite;
+  }
+
+  div:nth-child(1) {
+    animation-delay: -0.2s;
+  }
+  div:nth-child(3) {
+    animation-delay: 0.2s;
+  }
+
+  @keyframes dot {
+    0% {
+      transform: scale(0);
+    }
+    50% {
+      transform: scale(1);
+    }
+    100% {
+      transform: scale(0);
+    }
   }
 `;
 

--- a/src/Hooks/useSearchedCites.tsx
+++ b/src/Hooks/useSearchedCites.tsx
@@ -1,18 +1,11 @@
 import React from 'react';
 import { useRecoilState } from 'recoil';
 import { userCityAtom } from 'Atom/userLocationAtom';
-
-interface CityInfo {
-  cityName: string;
-  latLonData: {
-    longitude: number;
-    latitude: number;
-  };
-}
+import { CityWeatherType } from 'types/cityWeatherType';
 
 // 검색된 도시명과 좌표 정보를 Recoil을 사용하여 저장하고 삭제하는 훅
 const useSearchedCities = () => {
-  const [searchedCities, setSearchedCities] = useRecoilState<CityInfo[]>(userCityAtom);
+  const [searchedCities, setSearchedCities] = useRecoilState<CityWeatherType[]>(userCityAtom);
 
   const addSearchedCity = (cityName: string, latLonData: { longitude: number; latitude: number }) => {
     if (!searchedCities.some((city) => city.cityName === cityName)) {

--- a/src/types/cityWeatherType.ts
+++ b/src/types/cityWeatherType.ts
@@ -1,0 +1,7 @@
+export interface CityWeatherType {
+  cityName: string;
+  latLonData: {
+    longitude: number;
+    latitude: number;
+  };
+}


### PR DESCRIPTION
## 전달 사항

### 이슈번호: 32

- CardWaveList 에서 현재 위치 카드와 검색으로 나온 카드가 분리 되어 있었는데 앞으로 CityAtom으로 통합되므로 recoilvalule로 불러와 통합했습니다
- 만약 인덱스가 0이라면 현재 위치라는 텍스트로 교체되게 했습니다
- CardWaveList 검색으로 나온 카드의 경우 useSearchedCities 의 파일안 searchedCities state값을 가져오고 있어 CityAtom으로 변경했습니다
- 병현님이 만들어놓으신 CityInfo 타입의 경우 CardWaveList와 CityWeatherCard , useSearchedCities에 공통으로 사용되고 있어 type v폴더에 cityWeatherType 으로 따로 빼두었습니다.
- permission 페이지에서 유저에게 위치를 받아올때 해당 위도 경도에 맞는 도시명을 받아오고 CityAtom 제일 첫번째 배열로 집어넣습니다. 
- 위도, 경도에 맞는 도시명을 받아오는 API는 cityNameAPI 입니다
- 로딩할것이 있어 클릭되면 안되는 버튼의 경우 showLoadig props를 넘겨 버튼을 비활성화 시키고 로딩 애니메이션이 동작됩니다.

