### PR TITLE
Feat & Fix : 메인페이지 및 설정페이지 성별 및 나이 동기화 수정

### DIFF
--- a/src/API/useOpenWeatherAPI.tsx
+++ b/src/API/useOpenWeatherAPI.tsx
@@ -56,7 +56,6 @@ const useOpenWeatherAPI = () => {
           },
         })
         .then((res) => res.data);
-      console.log(response);
       return response;
     } catch (error) {
       console.error('AirPollution API 문제가 있습니다.', error);

--- a/src/Components/Home/SpeechBubble.tsx
+++ b/src/Components/Home/SpeechBubble.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect } from 'react';
+import React, { FC, useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { useQuery } from 'react-query';
 import { useRecoilValue } from 'recoil';
@@ -16,7 +16,7 @@ const SpeechBubble: FC = () => {
   const cityRes = useQuery('currentWeather', () => getCityWeather(latLonData[locationIndex].latLonData));
 
   const todayInfo = cityRes?.data;
-  const mainWeatherInfo = useMainWeatherInfo(todayInfo?.weather.main);
+  const mainWeatherInfo = useMainWeatherInfo(todayInfo?.weather[0].description);
 
   if (cityRes.isLoading) {
     return (
@@ -35,14 +35,14 @@ const SpeechBubble: FC = () => {
       {/* NOTE 화면 가로 크기가 변경되면 말풍선 가로 공백이 유동적이어서, 말풍선 꼬리를 따로 아래에 붙이는 방식으로 해결 */}
       <img src={speechBubbleTail} alt=' ' />
       {/* TODO 날씨 이미지마다 말풍선을 덮는 정도가 달라 이미지 파일 수정 필요 */}
-      <img src={mainWeatherInfo.icon} alt='today-weather' />
+      <img src={mainWeatherInfo?.icon} alt='today-weather' />
       <SpeechBubbleWeatherInfo
         cityName={latLonData[locationIndex].cityName}
         min={Math.ceil(todayInfo?.main.temp_min) + '°'}
         max={Math.ceil(todayInfo?.main.temp_max) + '°'}
         temp={Math.ceil(todayInfo?.main.temp) + '°'}
         humidity={Math.ceil(todayInfo?.main.humidity) + '%'}
-        label={mainWeatherInfo.label}
+        label={mainWeatherInfo?.label}
       />
       <SSpeechBubbleComment>
         날씨가 흐리고 일교차가 심하네요 <br />

--- a/src/Components/Login/ButtonAgeList.tsx
+++ b/src/Components/Login/ButtonAgeList.tsx
@@ -3,9 +3,9 @@ import styled from 'styled-components';
 import ButtonAge from 'Components/Login/ButtonAge';
 import { UserInfoProps } from 'Pages/Login';
 
-const ButtonAgeList: FC<UserInfoProps> = ({ setUserInfo }) => {
-  const [ageIndex, setAgeIndex] = useState<number | null>(null);
+const ButtonAgeList: FC<UserInfoProps> = ({ setUserInfo, age }) => {
   const ageList: string[] = ['10대', '20대', '30대', '40대', '50대'];
+  const [ageIndex, setAgeIndex] = useState<number>(ageList.indexOf(age));
 
   function handleActive(index: number, el: string): void {
     setAgeIndex(index);

--- a/src/Components/Login/ButtonGenderList.tsx
+++ b/src/Components/Login/ButtonGenderList.tsx
@@ -3,9 +3,9 @@ import styled from 'styled-components';
 import ButtonGender from 'Components/Login/ButtonGender';
 import { UserInfoProps } from 'Pages/Login';
 
-const ButtonGenderList: FC<UserInfoProps> = ({ setUserInfo }) => {
-  const [genderIndex, setGenderIndex] = useState<number | null>(null);
+const ButtonGenderList: FC<UserInfoProps> = ({ setUserInfo, gender }) => {
   const genderItem: string[] = ['남성', '여성'];
+  const [genderIndex, setGenderIndex] = useState<number>(genderItem.indexOf(gender));
 
   function handleActive(index: number, el: string): void {
     setGenderIndex(index);

--- a/src/Components/Setting/SetProfile.tsx
+++ b/src/Components/Setting/SetProfile.tsx
@@ -4,12 +4,10 @@ import styled from 'styled-components';
 import moreInfoIcn from 'Assets/setting-moreinfo-icon.svg';
 import { useNavigate } from 'react-router-dom';
 
-interface SetProfileProps {}
-
-const SetProfile: FC<SetProfileProps> = ({}) => {
+const SetProfile: FC = () => {
   const navigate = useNavigate();
   const updateProfile = () => {
-    navigate('/login', {
+    navigate('/profile', {
       state: {
         title: '프로필은 언제든 수정할 수 있어요.',
         button: '설정하기',

--- a/src/Components/common/useWeatherIcon.tsx
+++ b/src/Components/common/useWeatherIcon.tsx
@@ -59,23 +59,16 @@ interface Info {
   label: string;
 }
 
-export function useMainWeatherInfo(weather: string | undefined): Info {
-  switch (weather) {
-    case 'Thunderstorm':
-      return mainWeatherInfo.rainyThunder;
-    case 'Drizzle':
-      return mainWeatherInfo.showerRainy;
-    case 'Rain':
-      return mainWeatherInfo.rainy;
-    case 'Snow':
-      return mainWeatherInfo.snow;
-    case 'Clouds':
-      return mainWeatherInfo.fewClouds;
-    case 'Clear':
-      return mainWeatherInfo.clear;
-    default:
-      return mainWeatherInfo.mist;
-  }
+export function useMainWeatherInfo(weather: string): Info {
+  if (thunderstorm.includes(weather)) return mainWeatherInfo.rainyThunder;
+  else if (rain.includes(weather)) return mainWeatherInfo.rainy;
+  else if (drizzle.includes(weather)) return mainWeatherInfo.showerRainy;
+  else if (snow.includes(weather)) return mainWeatherInfo.snow;
+  else if (atmosphere.includes(weather)) return mainWeatherInfo.mist;
+  else if (weather === 'few clouds') return mainWeatherInfo.fewClouds;
+  else if (weather === 'scattered clouds') return mainWeatherInfo.scatteredClouds;
+  else if (brokenClouds.includes(weather)) return mainWeatherInfo.brokenClouds;
+  else return mainWeatherInfo.clear;
 }
 
 export function useParticulateImg(status: number): Info {

--- a/src/Pages/Login.tsx
+++ b/src/Pages/Login.tsx
@@ -27,8 +27,8 @@ const Login = () => {
     age: '',
   });
   const [isUserInfo, setIsUserInfo] = useRecoilState(userInfoAtom);
-  const title = location ? location.state.title : '날씨 뿡뿡에 오신걸 환영해요.';
-  const buttonLabel = location ? location.state.button : '시작하기';
+  const title = location.state ? location.state.title : '날씨 뿡뿡에 오신걸 환영해요.';
+  const buttonLabel = location.state ? location.state.button : '시작하기';
 
   const handledError = () => {
     if (userInfo.gender === '') {

--- a/src/Pages/Login.tsx
+++ b/src/Pages/Login.tsx
@@ -15,6 +15,8 @@ export interface UserInfo {
 
 export interface UserInfoProps {
   setUserInfo: React.Dispatch<React.SetStateAction<UserInfo>>;
+  gender: string;
+  age: string;
 }
 
 const Login = () => {
@@ -22,11 +24,11 @@ const Login = () => {
   const location = useLocation();
   const [showModal, setShowModal] = useState<boolean>(false);
   const [errorMessage, setErrorMessage] = useState<string>('');
-  const [userInfo, setUserInfo] = useState<UserInfo>({
-    gender: '',
-    age: '',
-  });
   const [isUserInfo, setIsUserInfo] = useRecoilState(userInfoAtom);
+  const [userInfo, setUserInfo] = useState<UserInfo>({
+    gender: isUserInfo.gender,
+    age: isUserInfo.age,
+  });
   const title = location.state ? location.state.title : '날씨 뿡뿡에 오신걸 환영해요.';
   const buttonLabel = location.state ? location.state.button : '시작하기';
 
@@ -53,8 +55,8 @@ const Login = () => {
         당신의 성별과 나이를 알려주세요.
       </p>
 
-      <ButtonGenderList setUserInfo={setUserInfo} />
-      <ButtonAgeList setUserInfo={setUserInfo} />
+      <ButtonGenderList setUserInfo={setUserInfo} gender={isUserInfo.gender} age='' />
+      <ButtonAgeList setUserInfo={setUserInfo} age={isUserInfo.age} gender='' />
       <Button onClick={handledError}>{buttonLabel}</Button>
     </SLoginLayout>
   );

--- a/src/Pages/Permission.tsx
+++ b/src/Pages/Permission.tsx
@@ -79,7 +79,7 @@ const Permission: FC = () => {
 
   function handleNextBtn() {
     if (userLocation && !showModal) {
-      navigate('/login');
+      navigate('/profile');
       // setUserLocation((prev: CityWeatherType[]) => [isLocation, ...prev]);
     } else {
       alert('필수 위치 권한에 동의 하지 않으셨습니다.');

--- a/src/Router/Router.tsx
+++ b/src/Router/Router.tsx
@@ -22,7 +22,7 @@ const router = createBrowserRouter([
         element: <Permission />,
       },
       {
-        path: 'login',
+        path: 'profile',
         element: <Login />,
       },
       {


### PR DESCRIPTION
## DONE
- 메인페이지 아이콘 반영 오류 해결
- login 바로 접근시 에러 해결
- 설정페이지 -> 성별 및 나이 기존에 저장된 변수로 활성화
- 미세먼지 불필요한 console.log 삭제
- mainWeatherIcon도 smallWeatherIcon 처럼 description 따라 가게끔 수정
- 범용성 있게 '/login' URL -> '/profile' URL로 수정
  - 컴포넌트 이름 등은 후일을 위해 Login으로 유지
  
  ## WILLDO
 - smallWeatherIcon이랑 mainWeatherIcon 둘이 달라서 검색페이지에서 보이는 아이콘이랑 메인에서 보이는 아이콘이 다름 통일 필요.