### PR TITLE
✨Feat: 서버에서 날씨 api를 업데이트 시킨 시간  노출 및 그 시간에 따른 날씨 카드 시간대 업데이트

### DIFF
--- a/src/API/useOpenWeatherAPI.tsx
+++ b/src/API/useOpenWeatherAPI.tsx
@@ -14,7 +14,6 @@ const useOpenWeatherAPI = () => {
   });
 
   async function getCityWeather(latLonData: { lon: number; lat: number }) {
-    console.log(latLonData);
     const lat = latLonData.lat;
     const lon = latLonData.lon;
     const requestURL = `?lat=${lat}&lon=${lon}&appid=${API_ID}&units=metric`;

--- a/src/Atom/updateDate.ts
+++ b/src/Atom/updateDate.ts
@@ -1,0 +1,11 @@
+import { atom } from 'recoil';
+
+export const updateDate = atom({
+  key: 'updateDate',
+  default: '',
+});
+
+export const userNight = atom({
+  key: 'userNight',
+  default: true,
+});

--- a/src/Atom/updateDate.ts
+++ b/src/Atom/updateDate.ts
@@ -1,4 +1,6 @@
 import { atom } from 'recoil';
+import { recoilPersist } from 'recoil-persist';
+const { persistAtom } = recoilPersist();
 
 export const updateDate = atom({
   key: 'updateDate',
@@ -7,5 +9,6 @@ export const updateDate = atom({
 
 export const userNight = atom({
   key: 'userNight',
-  default: true,
+  default: false,
+  effects_UNSTABLE: [persistAtom],
 });

--- a/src/Components/Home/SpeechBubble.tsx
+++ b/src/Components/Home/SpeechBubble.tsx
@@ -1,17 +1,19 @@
 import React, { FC, useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { useQuery } from 'react-query';
-import { useRecoilValue } from 'recoil';
+import { useRecoilValue, useRecoilState } from 'recoil';
 import { userCityAtom, currentUserIndexAtom } from 'Atom/userLocationAtom';
 import useOpenWeatherAPI from 'API/useOpenWeatherAPI';
-
 import SpeechBubbleWeatherInfo from 'Components/Home/SpeechBubbleWeatherInfo';
 import speechBubbleTail from 'Assets/speech-bubble-tail.svg';
 import { useMainWeatherInfo } from 'Components/common/useWeatherIcon';
+import { updateDate, userNight } from 'Atom/updateDate';
 
 const SpeechBubble: FC = () => {
   const latLonData = useRecoilValue(userCityAtom);
   const locationIndex = useRecoilValue(currentUserIndexAtom);
+  const [isUpdateDate, setIsUpdateDate] = useRecoilState(updateDate);
+  const [updateNight, setUpdateNight] = useRecoilState(userNight);
   const { getCityWeather } = useOpenWeatherAPI();
   const cityRes = useQuery('currentWeather', () => getCityWeather(latLonData[locationIndex].latLonData));
 
@@ -28,6 +30,22 @@ const SpeechBubble: FC = () => {
   }
   if (cityRes.error) {
     return <p>로딩중 문제가 발생했습니다.</p>;
+  }
+
+  if (cityRes.dataUpdatedAt) {
+    const date = new Date(cityRes.dataUpdatedAt);
+    date.setHours(date.getHours() + 9);
+    const formattedDate = date.toISOString().slice(0, 16).replace('T', ' ');
+    setIsUpdateDate(formattedDate);
+
+    const isNight: number | string = parseInt(formattedDate.slice(10, 13));
+    if (formattedDate && isNight > 15) {
+      setUpdateNight(true);
+    } else if (0 <= isNight && isNight < 5) {
+      setUpdateNight(true);
+    } else {
+      setUpdateNight(false);
+    }
   }
 
   return (

--- a/src/Components/Search/CardWeather.tsx
+++ b/src/Components/Search/CardWeather.tsx
@@ -45,6 +45,7 @@ const CardWeather: FC<CardWeatherProps> = ({ temp, max, min, weather, name }) =>
     }
     navigate('/');
   }
+  console.log(weather);
 
   return (
     <SCardWeatherWrap isNight={isNight} onClick={handleWeatherCard}>

--- a/src/Components/Search/CardWeather.tsx
+++ b/src/Components/Search/CardWeather.tsx
@@ -3,6 +3,8 @@ import styled from 'styled-components';
 import CardWave from './CardWave';
 import CardRain from './CardRain';
 import { useWeatherIcon, useWeatherKr } from 'Components/common/useWeatherIcon';
+import { useRecoilValue } from 'recoil';
+import { userNight } from 'Atom/updateDate';
 import useSearchedCities from 'Hooks/useSearchedCites';
 import { useNavigate } from 'react-router-dom';
 
@@ -15,7 +17,7 @@ interface CardWeatherProps {
 }
 
 const CardWeather: FC<CardWeatherProps> = ({ temp, max, min, weather, name }) => {
-  const [isNight, setIsNight] = useState<boolean>(false);
+  const isNight = useRecoilValue(userNight);
   const [isRain, setIsRain] = useState<boolean>(false);
   const currentDate = new Date();
   const currentTime: number = Number(currentDate.toTimeString().slice(0, 2));
@@ -23,14 +25,6 @@ const CardWeather: FC<CardWeatherProps> = ({ temp, max, min, weather, name }) =>
   const navigate = useNavigate();
 
   useEffect(() => {
-    if (15 < currentTime) {
-      setIsNight(true);
-    } else if (0 <= currentTime && currentTime < 5) {
-      setIsNight(true);
-    } else {
-      setIsNight(false);
-    }
-
     switch (weather) {
       case 'Thunderstorm':
         setIsRain(true);

--- a/src/Components/Search/CityWeatherCard.tsx
+++ b/src/Components/Search/CityWeatherCard.tsx
@@ -30,13 +30,13 @@ const CityWeatherCard: FC<CityWeatherCardProps> = ({ cityName, latLonData }) => 
   if (isError) {
     return <div>날씨 데이터를 불러올 수 없습니다</div>;
   }
-  console.log(data);
+
   return (
     <CardWeather
       temp={data.main.temp}
       max={data.main.temp_max}
       min={data.main.temp_min}
-      weather={data.weather[0].main}
+      weather={data.weather[0].description}
       name={cityName}
     />
   );

--- a/src/Components/common/useWeatherIcon.tsx
+++ b/src/Components/common/useWeatherIcon.tsx
@@ -36,21 +36,73 @@ export function useWeatherSmallIcon(weather: string) {
 }
 
 export function useWeatherKr(weather: string | undefined): string | undefined {
-  switch (weather) {
-    case 'Thunderstorm':
-      return '천둥 번개';
-    case 'Drizzle':
-      return '비 조금';
-    case 'Rain':
-      return '비 옴';
-    case 'Snow':
-      return '눈 옴';
-    case 'Clouds':
-      return '구름 조금';
-    case 'Clear':
-      return '맑은 날씨';
-    default:
-      return '흐린 날씨';
+  if (weather?.includes('thunderstorm')) {
+    return '비와 천둥번개가 칩니다';
+  } else if (weather?.includes('drizzle')) {
+    return '이슬비가 옵니다';
+  } else if (weather?.includes('rain')) {
+    switch (weather) {
+      case 'light rain':
+        return '약간의 비가 옵니다';
+      case 'moderate rain':
+        return '비가 옵니다';
+      case 'heavy intensity rain':
+        return '많은 비가 옵니다';
+      case 'very heavy rain':
+        return '많은 비가 옵니다';
+      case 'extreme rain':
+        return '폭우가 옵니다';
+      case 'freezing rain':
+        return '비가 옵니다';
+      case 'light intensity shower rain':
+        return '많은 양의 소나기가 옵니다';
+      case 'heavy intensity shower rain':
+        return '많은 양의 소나기가 옵니다';
+      case 'shower rain':
+        return '소나기가 옵니다';
+      case 'ragged shower rain':
+        return '소나기가 옵니다';
+      case 'light rain and snow':
+        return '눈 또는 비가 옵니다';
+      case 'rain and snow':
+        return '눈 또는 비가 옵니다';
+    }
+  } else if (weather?.includes('snow')) {
+    switch (weather) {
+      case 'light snow':
+        return '약간의 눈이 내립니다';
+      case 'snow':
+        return '눈이 내립니다';
+      case 'heavy snow':
+        return '많은 눈이 내립니다';
+      case 'sleet':
+        return '진눈깨비';
+      case 'light shower sleet':
+        return '진눈깨비';
+      case 'shower sleet':
+        return '잠깐의 진눈깨비';
+      case 'light shower snow':
+        return '약간의 눈이 내립니다';
+      case 'shower snown':
+        return '약간의 눈이 내립니다';
+      case 'heavy shower snow':
+        return '약간의 눈이 내립니다';
+    }
+  } else if (weather?.includes('clear')) {
+    return '맑은 날씨입니다';
+  } else if (weather?.includes('clouds')) {
+    switch (weather) {
+      case 'few clouds: 11-25%':
+        return '적은 구름이 꼈습니다';
+      case 'scattered clouds: 25-50%':
+        return '약간의 구름이 꼈습니다';
+      case 'broken clouds: 51-84%':
+        return '많은 양의 구름이 꼈습니다';
+      case 'overcast clouds: 85-100%':
+        return '흐린 날씨 입니다';
+    }
+  } else {
+    return '안개가 꼈습니다';
   }
 }
 

--- a/src/Pages/Home.tsx
+++ b/src/Pages/Home.tsx
@@ -3,17 +3,19 @@ import Header from 'Components/common/Header';
 import BottomNav from 'Components/common/BottomNav';
 import Character from 'Components/Home/Character';
 import ParticulateMatter from 'Components/Home/ParticulateMatter';
-
+import { useRecoilValue } from 'recoil';
+import { updateDate } from 'Atom/updateDate';
 import HourlyForecast from 'Components/Home/HourlyForecast';
 import SpeechBubble from 'Components/Home/SpeechBubble';
 import { useNavigate, useLocation } from 'react-router';
 
 const Home = () => {
+  const date = useRecoilValue(updateDate);
   return (
     <>
       <Header />
       <main>
-        <SUpdateDate>AM 11:10 업데이트</SUpdateDate>
+        <SUpdateDate>{date} 업데이트</SUpdateDate>
         <SpeechBubble />
         <Character />
         <SPMHourlySection>


### PR DESCRIPTION
## 💬 무엇을 위한 PR인가요?
- [x] 기능 추가
- [ ] 마크업 & 스타일
- [x] 리팩토링
- [ ] 문서 수정
- [ ] 버그 수정
- [ ] 도와주세요
- [ ] 개발 환경 세팅
홈에서 업데이트 되는 시간 출력 및 그 시간 기준 카드 위젯 시간대 설정

## 💬 전달사항
- react query의 내장 속성인 dataUpdatedAt 을 new Date 와 toISOString를 이용하여 'YYYY-MM-DD 시간대"로 보여준 후 home에 노출
- 위젯이 처음에 낮시간 으로 잠깜 보이는 이슈가 있어 dataUpdatedAt가 업데이트 될때 밤/낮 상태를 변경시키고 이를 recoil에 따로 전역으로 상태를 관리
- useWeatherKr의 한글 날씨를 description기준으로 더 상세하게 구별했습니다. (rain, snow, cloudes)

## 🐞 문제사항

## 💬 Issue Number
#48 

open : #
close : #
