### PR TITLE
Design: 메인, 바텀내비

### DIFF
--- a/src/Components/common/BottomNav.tsx
+++ b/src/Components/common/BottomNav.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useEffect } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import styled from 'styled-components';
 import { useRecoilState } from 'recoil';
@@ -96,6 +96,7 @@ const SNavLayout = styled.nav`
   bottom: 0;
   left: 0;
   right: 0;
+  z-index: 20;
 
   background-color: white;
 `;

--- a/src/Components/style/SLayout.tsx
+++ b/src/Components/style/SLayout.tsx
@@ -9,6 +9,7 @@ const SLayout = styled.div`
   padding: 0 24px;
   box-sizing: border-box;
   background-color: var(--bg);
+  overflow: auto;
 `;
 
 export default SLayout;

--- a/src/Pages/Home.tsx
+++ b/src/Pages/Home.tsx
@@ -3,10 +3,8 @@ import Header from 'Components/common/Header';
 import BottomNav from 'Components/common/BottomNav';
 import Character from 'Components/Home/Character';
 import ParticulateMatter from 'Components/Home/ParticulateMatter';
-
 import HourlyForecast from 'Components/Home/HourlyForecast';
 import SpeechBubble from 'Components/Home/SpeechBubble';
-import { useNavigate, useLocation } from 'react-router';
 
 const Home = () => {
   return (
@@ -38,4 +36,5 @@ const SPMHourlySection = styled.section`
   display: flex;
   align-items: center;
   gap: 10px;
+  margin-bottom: 80px;
 `;


### PR DESCRIPTION
## 💬 무엇을 위한 PR인가요?

- [ ] 기능 추가
- [x] 마크업 & 스타일
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 버그 수정
- [ ] 도와주세요
- [ ] 개발 환경 세팅

## 💬 전달사항

- 메인 scroll auto로 변경
- 바텀내비 z-index 20 추가
- 메인에 scroll이 생길경우 내비때문에 안보여서 시간대별,미세먼지 섹션에 margin bottom추가 사용하지 않는 import 삭제

## 🐞 문제사항

## 💬 Issue Number

open : #50 
close : #
