### PR TITLE
반응형 초안

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,34 +1,36 @@
 import { useEffect } from 'react';
 import { Outlet } from 'react-router-dom';
-import { RecoilRoot } from 'recoil';
+import { RecoilRoot, useRecoilValue } from 'recoil';
 import GlobalStyle from 'GlobalStyle';
 import SLayout from 'Components/style/SLayout';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { ReactQueryDevtools } from 'react-query/devtools';
 import { StyleSheetManager } from 'styled-components';
+import useSetScreen from 'Hooks/useSetScreen';
 
 const queryClient = new QueryClient();
 
 function App() {
-  const setScreenSize = () => {
-    let vh = window.innerHeight * 0.01;
-    document.documentElement.style.setProperty('--vh', `${vh}px`);
-  };
   useEffect(() => {
-    setScreenSize();
+    const setHeight = () => {
+      let vh = window.innerHeight * 0.01;
+      document.documentElement.style.setProperty('--vh', `${vh}px`);
+    };
+
+    setHeight();
   }, []);
+
+  const isPC = useSetScreen();
 
   return (
     <QueryClientProvider client={queryClient}>
       <ReactQueryDevtools initialIsOpen={true} />
-      <RecoilRoot>
-        <StyleSheetManager shouldForwardProp={(prop) => prop !== 'active'}>
-          <SLayout>
-            <GlobalStyle />
-            <Outlet />
-          </SLayout>
-        </StyleSheetManager>
-      </RecoilRoot>
+      <StyleSheetManager shouldForwardProp={(prop) => prop !== 'active'}>
+        <SLayout $isPC={isPC}>
+          <GlobalStyle />
+          <Outlet />
+        </SLayout>
+      </StyleSheetManager>
     </QueryClientProvider>
   );
 }

--- a/src/Atom/pcScreen.ts
+++ b/src/Atom/pcScreen.ts
@@ -1,0 +1,11 @@
+import { atom } from 'recoil';
+import { recoilPersist } from 'recoil-persist';
+const { persistAtom } = recoilPersist();
+
+const pcScreen = atom({
+  key: 'pcScreen',
+  default: false,
+  effects_UNSTABLE: [persistAtom],
+});
+
+export default pcScreen;

--- a/src/Components/Home/SpeechBubble.tsx
+++ b/src/Components/Home/SpeechBubble.tsx
@@ -1,7 +1,7 @@
 import React, { FC, useEffect } from 'react';
 import styled from 'styled-components';
 import { useQuery } from 'react-query';
-import { useRecoilValue, useRecoilState } from 'recoil';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { userCityAtom, currentUserIndexAtom } from 'Atom/userLocationAtom';
 import useOpenWeatherAPI from 'API/useOpenWeatherAPI';
 import SpeechBubbleWeatherInfo from 'Components/Home/SpeechBubbleWeatherInfo';
@@ -14,9 +14,9 @@ import SpeechBubbleComment from './SpeechBubbleComment';
 const SpeechBubble: FC = () => {
   const latLonData = useRecoilValue(userCityAtom);
   const locationIndex = useRecoilValue(currentUserIndexAtom);
-  const [isUpdateDate, setIsUpdateDate] = useRecoilState(updateDate);
-  const [updateNight, setUpdateNight] = useRecoilState(userNight);
-  const [todayWeather, setTodayWeather] = useRecoilState(dailyWeather);
+  const setIsUpdateDate = useSetRecoilState(updateDate);
+  const setUpdateNight = useSetRecoilState(userNight);
+  const setTodayWeather = useSetRecoilState(dailyWeather);
   const { getCityWeather } = useOpenWeatherAPI();
   const cityRes = useQuery('currentWeather', () => getCityWeather(latLonData[locationIndex].latLonData));
 

--- a/src/Components/Home/SpeechBubbleComment.tsx
+++ b/src/Components/Home/SpeechBubbleComment.tsx
@@ -1,6 +1,8 @@
-import React, { FC } from 'react';
+import { FC } from 'react';
 import styled from 'styled-components';
+import { useRecoilValue } from 'recoil';
 import useDailyComments from 'Components/common/useDailyComments';
+import pcScreen from 'Atom/pcScreen';
 
 interface SpeechBubbleCommentProps {
   todayWeather: string;
@@ -8,10 +10,11 @@ interface SpeechBubbleCommentProps {
 }
 
 const SpeechBubbleComment: FC<SpeechBubbleCommentProps> = ({ todayWeather, feels_like }) => {
+  const isPC = useRecoilValue(pcScreen);
   const { commentWeather, commentTemp, commentClothes, commentCaution } = useDailyComments(todayWeather, feels_like);
 
   return (
-    <SSpeechBubbleCommentLayout>
+    <SSpeechBubbleCommentLayout $isPC={isPC}>
       {commentWeather()} {commentTemp()}
       <br />
       {commentClothes()}
@@ -23,9 +26,9 @@ const SpeechBubbleComment: FC<SpeechBubbleCommentProps> = ({ todayWeather, feels
 
 export default SpeechBubbleComment;
 
-const SSpeechBubbleCommentLayout = styled.section`
+const SSpeechBubbleCommentLayout = styled.section<{ $isPC: boolean }>`
   padding-top: 24px;
-  font-size: 16px;
+  font-size: ${(props) => (props.$isPC ? '18px' : '16px')};
   color: var(--gray-800);
   font-weight: 500;
   border-top: 1px solid var(--gray-200);

--- a/src/Components/Home/SpeechBubbleWeatherInfo.tsx
+++ b/src/Components/Home/SpeechBubbleWeatherInfo.tsx
@@ -1,6 +1,8 @@
-import React, { FC } from 'react';
+import { FC } from 'react';
 import styled from 'styled-components';
+import { useRecoilValue } from 'recoil';
 import locationIcn from 'Assets/icon-location.svg';
+import pcScreen from 'Atom/pcScreen';
 
 interface SpeechBubbleWeatherInfoProps {
   cityName: string;
@@ -21,15 +23,16 @@ const SpeechBubbleWeatherInfo: FC<SpeechBubbleWeatherInfoProps> = ({
   label,
   cityName,
 }) => {
+  const isPC = useRecoilValue(pcScreen);
   return (
     <SSpeechBubbleWeatherInfoLayout>
-      <SAreaWeatherWrap>
+      <SAreaWeatherWrap $isPC={isPC}>
         <img src={locationIcn} alt='icon-location' />
         <span>
           {cityName} <strong>{label}</strong>
         </span>
       </SAreaWeatherWrap>
-      <STemperatureWrap>
+      <STemperatureWrap $isPC={isPC}>
         <li>
           <p>{temp}</p>
         </li>
@@ -59,7 +62,7 @@ export default SpeechBubbleWeatherInfo;
 const SSpeechBubbleWeatherInfoLayout = styled.section`
   padding-top: 25px;
 `;
-const SAreaWeatherWrap = styled.div`
+const SAreaWeatherWrap = styled.div<{ $isPC: boolean }>`
   text-align: left;
   display: flex;
   align-items: center;
@@ -70,7 +73,7 @@ const SAreaWeatherWrap = styled.div`
 
   span {
     color: var(--gray-800);
-    font-size: 14px;
+    font-size: ${(props) => (props.$isPC ? '16px' : '14px')};
 
     strong {
       color: var(--orange);
@@ -78,7 +81,7 @@ const SAreaWeatherWrap = styled.div`
   }
 `;
 
-const STemperatureWrap = styled.ul`
+const STemperatureWrap = styled.ul<{ $isPC: boolean }>`
   display: flex;
   height: 80px;
   width: 100%;
@@ -92,12 +95,12 @@ const STemperatureWrap = styled.ul`
   }
 
   li:not(:first-child) {
-    font-size: 10px;
+    font-size: ${(props) => (props.$isPC ? '16px' : '10px')};
     color: var(--gray-800);
 
     p:nth-of-type(2) {
       padding-top: 12px;
-      font-size: 16px;
+      font-size: ${(props) => (props.$isPC ? '20px' : '16px')};
       color: black;
     }
   }

--- a/src/Components/Weekly/WeeklyForecast.tsx
+++ b/src/Components/Weekly/WeeklyForecast.tsx
@@ -1,10 +1,13 @@
 import { FC } from 'react';
 import { styled } from 'styled-components';
+import { useRecoilValue } from 'recoil';
 import WeeklyItem from 'Components/Weekly/WeeklyItem';
 import { useWeatherSmallIcon } from 'Components/common/useWeatherIcon';
 import useForecastData from 'Hooks/useForecastData';
+import pcScreen from 'Atom/pcScreen';
 
 const WeeklyForecast: FC = () => {
+  const isPC = useRecoilValue(pcScreen);
   const {
     days,
     today,
@@ -27,7 +30,7 @@ const WeeklyForecast: FC = () => {
 
   return (
     <>
-      <STitle>
+      <STitle $isPC={isPC}>
         <strong>{latLonData[currentCityIndex].cityName}</strong> 주간 예보
       </STitle>
       <SLayout>
@@ -57,9 +60,9 @@ const WeeklyForecast: FC = () => {
 
 export default WeeklyForecast;
 
-const STitle = styled.h1`
+const STitle = styled.h1<{ $isPC: boolean }>`
   margin-bottom: 40px;
-  font-size: 24px;
+  font-size: ${({ $isPC }) => ($isPC ? '28px' : '24px')};
   font-weight: 600;
 
   strong {

--- a/src/Components/Weekly/WeeklyItem.tsx
+++ b/src/Components/Weekly/WeeklyItem.tsx
@@ -1,5 +1,7 @@
-import React, { FC } from 'react';
+import { FC } from 'react';
 import styled, { css } from 'styled-components';
+import { useRecoilValue } from 'recoil';
+import pcScreen from 'Atom/pcScreen';
 
 interface WeeklyItemProps {
   day: string | number | undefined;
@@ -11,14 +13,15 @@ interface WeeklyItemProps {
 }
 
 const WeeklyItem: FC<WeeklyItemProps> = ({ day, min, max, temp, icon, $today = false }) => {
+  const isPC = useRecoilValue(pcScreen);
   return (
-    <SLayout>
+    <SLayout $isPC={isPC}>
       <h2>{day}</h2>
-      <SMinMaxWrap $today={$today}>
+      <SMinMaxWrap $today={$today} $isPC={isPC}>
         <span>최저: {min}</span>
         <span>최고: {max}</span>
       </SMinMaxWrap>
-      <STempWrap>
+      <STempWrap $isPC={isPC}>
         <img src={icon} alt='이날의 날씨 아이콘' />
         <span>{temp ? temp : max}</span>
       </STempWrap>
@@ -28,23 +31,23 @@ const WeeklyItem: FC<WeeklyItemProps> = ({ day, min, max, temp, icon, $today = f
 
 export default WeeklyItem;
 
-const SLayout = styled.div`
+const SLayout = styled.div<{ $isPC: boolean }>`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 20px 21px;
+  padding: ${(props) => (props.$isPC ? '22px 45px' : '15px 21px')};
   background-color: #fff;
   border: 1px solid var(--gray-400);
   border-radius: 10px;
 
   h2 {
-    font-size: 20px;
+    font-size: ${(props) => (props.$isPC ? '22px' : '20px')};
     font-weight: 500;
   }
 `;
 
-const SMinMaxWrap = styled.div<{ $today: boolean }>`
-  font-size: 12px;
+const SMinMaxWrap = styled.div<{ $today: boolean; $isPC: boolean }>`
+  font-size: ${(props) => (props.$isPC ? '16px' : '12px')};
   color: var(--gray-800);
 
   span:nth-of-type(1)::after {
@@ -66,7 +69,7 @@ const SMinMaxWrap = styled.div<{ $today: boolean }>`
   }
 `;
 
-const STempWrap = styled.div`
+const STempWrap = styled.div<{ $isPC: boolean }>`
   display: flex;
   align-items: center;
 
@@ -75,7 +78,7 @@ const STempWrap = styled.div`
   }
 
   span {
-    font-size: 24px;
+    font-size: ${(props) => (props.$isPC ? '30px' : '24px')};
     font-weight: bold;
     color: var(--orange);
   }

--- a/src/Components/common/BottomNav.tsx
+++ b/src/Components/common/BottomNav.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import styled from 'styled-components';
-import { useRecoilState } from 'recoil';
+import { useRecoilState, useRecoilValue } from 'recoil';
 import { bottomNavAtom } from 'Atom/BottomNavStore';
 import HomeIcon from 'Assets/home-icon.svg';
 import SearchIcon from 'Assets/search-icon.svg';
@@ -11,8 +11,10 @@ import HomeIcon_Fill from 'Assets/home-fill-icon.svg';
 import SearchIcon_Fill from 'Assets/search-fill-icon.svg';
 import WeeklyIcon_Fill from 'Assets/weekly-fill-icon.svg';
 import SettingIcon_Fill from 'Assets/setting-fill-icon.svg';
+import pcScreen from 'Atom/pcScreen';
 
 const BottomNav: React.FC = () => {
+  const isPC = useRecoilValue(pcScreen);
   const [bottomNavIndexState, setBottomNavIndexState] = useRecoilState<number>(bottomNavAtom);
   const navItems: string[] = ['home', 'search', 'weekly', 'setting'];
   const iconArr: { active: string; inactive: string }[] = [
@@ -54,7 +56,7 @@ const BottomNav: React.FC = () => {
     setBottomNavIndexState(index);
   }
   return (
-    <SNavLayout>
+    <SNavLayout $isPC={isPC}>
       <SListStyle>
         {navItems.map((item, index) => (
           <SItemStyle key={index} active={index === bottomNavIndexState}>
@@ -89,8 +91,8 @@ const LinkBtn: React.FC<LinkBtnProps> = ({ src, text, active, onClick }) => {
 
 export default BottomNav;
 
-const SNavLayout = styled.nav`
-  max-width: 430px;
+const SNavLayout = styled.nav<{ $isPC: boolean }>`
+  max-width: ${(props) => (props.$isPC ? '768px' : '430px')};
   margin: 0 auto;
   position: fixed;
   bottom: 0;

--- a/src/Components/style/SLayout.tsx
+++ b/src/Components/style/SLayout.tsx
@@ -1,8 +1,8 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
-const SLayout = styled.div`
+const SLayout = styled.div<{ $isPC: boolean }>`
   position: relative;
-  max-width: 430px;
+  max-width: ${(props) => (props.$isPC ? '768px' : '430px')};
   min-width: 375px;
   height: calc(var(--vh, 1vh) * 100);
   margin: 0 auto;

--- a/src/Hooks/useSetScreen.tsx
+++ b/src/Hooks/useSetScreen.tsx
@@ -1,0 +1,21 @@
+import { useEffect } from 'react';
+import { useRecoilState } from 'recoil';
+import pcScreen from 'Atom/pcScreen';
+
+const useSetScreen: () => boolean = () => {
+  const [isPCScreen, setIsPCScreen] = useRecoilState(pcScreen);
+
+  useEffect(() => {
+    function resizeScreen() {
+      if (window.innerWidth > 768) setIsPCScreen(true);
+      else setIsPCScreen(false);
+    }
+
+    resizeScreen();
+    window.addEventListener('resize', resizeScreen);
+  }, [setIsPCScreen]);
+
+  return isPCScreen;
+};
+
+export default useSetScreen;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,11 +2,12 @@ import React from 'react';
 import { createRoot } from 'react-dom/client';
 import router from 'Router/Router';
 import { RouterProvider } from 'react-router-dom';
+import { RecoilRoot } from 'recoil';
 
 const container = document.getElementById('root') as Element | DocumentFragment;
 const root = createRoot(container);
 root.render(
-  <React.StrictMode>
+  <RecoilRoot>
     <RouterProvider router={router} />
-  </React.StrictMode>,
+  </RecoilRoot>,
 );


### PR DESCRIPTION
## 💬 무엇을 위한 PR인가요?

- [x] 기능 추가
- [x] 마크업 & 스타일
- [x] 리팩토링
- [ ] 문서 수정
- [ ] 버그 수정
- [ ] 도와주세요
- [ ] 개발 환경 세팅

## 💬 전달사항

- pcScreen Atom 추가
  - recoil로 전역에서 관리하기
- PC screen 커스텀 훅 추가 
  - app 에서 window innerWidth 감지하여 pcScreen atom set하는 용
- 반응형 초안
  - 홈: 폰트 사이즈 크게 
  - 주간: padding, 폰트 사이즈 크게
- SpeechBubble에서 useRecoilState로   사용하지 않는 변수 발생, useSetRecoilState로 변경
- React.StricMode 지우고 RecoilRoot index.ts로 이동

## 🐞 문제사항
- 홈 Main의 요소들 간격을 넓히려고 했으나 다른 페이지는 상단에 위치해 있기 때문에 통일성이 많이 떨어짐..
- 좀 더 회의를 해봐야할듯..

## 💬 Issue Number

open : #58 
close : #
